### PR TITLE
Method Dependencies

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,7 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <source>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory suffix=".php">src</directory>
     </include>

--- a/src/Mapping/Normalizer.php
+++ b/src/Mapping/Normalizer.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace Zolex\VOM\Mapping;
 
+use Zolex\VOM\Metadata\ModelMetadata;
+
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final class Normalizer
 {
     public function __construct(
         private readonly ?string $accessor = null,
-        private readonly ?string $scenario = null,
+        private readonly ?string $scenario = ModelMetadata::DEFAULT_SCENARIO,
     ) {
     }
 

--- a/src/Metadata/DenormalizerMetadata.php
+++ b/src/Metadata/DenormalizerMetadata.php
@@ -18,14 +18,14 @@ class DenormalizerMetadata extends AbstractCallableMetadata
     public function __construct(
         string $class,
         string $method,
-        /* @var array|ArgumentMetadata[] $arguments */
-        array $arguments,
-        private readonly string $virtualPropertyName,
+        /* @var array|ArgumentMetadata[][] $arguments */
+        array $arguments = [],
+        private readonly ?string $virtualPropertyName = null,
     ) {
         parent::__construct($class, $method, $arguments);
     }
 
-    public function getPropertyName(): string
+    public function getPropertyName(): ?string
     {
         return $this->virtualPropertyName;
     }

--- a/src/Metadata/FactoryMetadata.php
+++ b/src/Metadata/FactoryMetadata.php
@@ -18,7 +18,7 @@ class FactoryMetadata extends AbstractCallableMetadata
     public function __construct(
         string $class,
         string $method,
-        /* @var array|ArgumentMetadata[] $arguments */
+        /* @var array|ArgumentMetadata[][] $arguments */
         array $arguments = [],
         private int $priority = 0,
     ) {

--- a/src/Metadata/ModelMetadata.php
+++ b/src/Metadata/ModelMetadata.php
@@ -29,6 +29,12 @@ final class ModelMetadata
      * @var array|ArgumentMetadata[][]
      */
     private array $constructorArguments = [];
+
+    /**
+     * @var array|DependencyInjectionMetadata[]
+     */
+    private array $constructorDependencies = [];
+
     private ?Model $attribute = null;
 
     /**
@@ -103,7 +109,7 @@ final class ModelMetadata
      */
     public function getConstructorArguments(string $scenario = self::DEFAULT_SCENARIO): array
     {
-        return $this->constructorArguments[$scenario] ?? [];
+        return array_merge($this->constructorArguments[$scenario] ?? [], $this->constructorDependencies);
     }
 
     /**
@@ -119,6 +125,14 @@ final class ModelMetadata
         }
 
         $this->constructorArguments[$scenario][$property->getName()] = $property;
+    }
+
+    /**
+     * Adds a constructor argument to the model, that is a registered dependency.
+     */
+    public function addConstructorDependency(DependencyInjectionMetadata $dependency): void
+    {
+        $this->constructorDependencies[$dependency->getName()] = $dependency;
     }
 
     /**

--- a/src/Metadata/NormalizerMetadata.php
+++ b/src/Metadata/NormalizerMetadata.php
@@ -20,10 +20,12 @@ class NormalizerMetadata extends AbstractCallableMetadata
     public function __construct(
         string $class,
         string $method,
-        private readonly ?string $virtualPropertyName,
+        /* @var array|ArgumentMetadata[][] $arguments */
+        array $arguments,
         private readonly Normalizer $attribute,
+        private readonly ?string $virtualPropertyName = null,
     ) {
-        parent::__construct($class, $method);
+        parent::__construct($class, $method, $arguments);
     }
 
     public function getPropertyName(): ?string

--- a/src/Serializer/Factory/VersatileObjectMapperFactory.php
+++ b/src/Serializer/Factory/VersatileObjectMapperFactory.php
@@ -71,7 +71,7 @@ class VersatileObjectMapperFactory
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         self::$metadataFactory = new ModelMetadataFactory($propertyInfo);
         foreach ($deps as $dep) {
-            self::$metadataFactory->injectDenormalizerDependency($dep);
+            self::$metadataFactory->injectMethodDependency($dep);
         }
         if ($cacheItemPool) {
             self::$metadataFactory = new CachedModelMetadataFactory($cacheItemPool, self::$metadataFactory);

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -30,6 +30,11 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
+                ->arrayNode('method_dependencies')
+                    ->scalarPrototype()
+                ->end()->end()
+
+                // deprecated. to be removed in future release
                 ->arrayNode('denormalizer')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/Symfony/Bundle/DependencyInjection/ZolexVOMExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ZolexVOMExtension.php
@@ -41,14 +41,19 @@ class ZolexVOMExtension extends Extension implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         $factory = $container->getDefinition('zolex_vom.metadata.model_metadata_factory');
-        foreach ($this->config['denormalizer']['dependencies'] as $service) {
+
+        if (\count($this->config['denormalizer']['dependencies'])) {
+            trigger_deprecation('zolex/vom', '0.8.0', 'the config key "denormalizer.dependencies" is deprecated. Use method_dependencies instead.');
+        }
+
+        foreach (array_merge($this->config['method_dependencies'], $this->config['denormalizer']['dependencies']) as $service) {
             $service = ltrim($service, '@');
             if (!$container->hasDefinition($service)) {
-                throw new InvalidArgumentException('Denormalizer dependency not found in container: '.$service);
+                throw new InvalidArgumentException('Method dependency not found in container: '.$service);
             }
 
             $serviceDefinition = $container->getDefinition($service);
-            $factory->addMethodCall('injectDenormalizerDependency', [$serviceDefinition]);
+            $factory->addMethodCall('injectMethodDependency', [$serviceDefinition]);
         }
 
         if ($container->getParameter('kernel.debug')) {

--- a/src/Symfony/Bundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/Resources/config/services.xml
@@ -6,9 +6,6 @@
     <services>
         <service id="zolex_vom.metadata.model_metadata_factory" class="Zolex\VOM\Metadata\Factory\ModelMetadataFactory">
             <argument type="service" id="property_info" />
-            <call method="injectDenormalizerDependency">
-                <argument type="service" id="parameter_bag" />
-            </call>
         </service>
         <service id="Zolex\VOM\Metadata\Factory\ModelMetadataFactoryInterface" alias="zolex_vom.metadata.model_metadata_factory" />
 

--- a/tests/Fixtures/DenormalizerWithoutArguments.php
+++ b/tests/Fixtures/DenormalizerWithoutArguments.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DenormalizerWithoutArguments
+{
+    #[VOM\Denormalizer]
+    public function denormalizeNothing(): void
+    {
+    }
+}

--- a/tests/Fixtures/DependencyInConstructor.php
+++ b/tests/Fixtures/DependencyInConstructor.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DependencyInConstructor
+{
+    public bool $example;
+    public string $type;
+    public string $format;
+
+    public function __construct(
+        #[VOM\Argument]
+        string $type,
+        ParameterBagInterface $parameterBag,
+        #[VOM\Argument]
+        ?string $format,
+    ) {
+        $this->example = $parameterBag->get('example');
+        $this->type = $type;
+        $this->format = $format;
+    }
+}

--- a/tests/Fixtures/DependencyInConstructorMissing.php
+++ b/tests/Fixtures/DependencyInConstructorMissing.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Psr\Log\LoggerInterface;
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DependencyInConstructorMissing
+{
+    public function __construct(
+        #[VOM\Argument]
+        string $type,
+        LoggerInterface $logger,
+        #[VOM\Argument]
+        ?string $format,
+    ) {
+    }
+}

--- a/tests/Fixtures/DependencyInConstructorPropertyPromotion.php
+++ b/tests/Fixtures/DependencyInConstructorPropertyPromotion.php
@@ -17,14 +17,19 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Zolex\VOM\Mapping as VOM;
 
 #[VOM\Model]
-class DenormalizerDependency
+class DependencyInConstructorPropertyPromotion
 {
-    public bool $example;
+    public function __construct(
+        #[VOM\Argument]
+        public string $type,
+        private ParameterBagInterface $parameterBag,
+        #[VOM\Argument]
+        public ?string $format,
+    ) {
+    }
 
-    #[VOM\Denormalizer]
-    public function denormalizeData(
-        ParameterBagInterface $parameterBag,
-    ): void {
-        $this->example = $parameterBag->get('example');
+    public function getExample(): bool
+    {
+        return $this->parameterBag->get('example');
     }
 }

--- a/tests/Fixtures/DependencyInDenormalizer.php
+++ b/tests/Fixtures/DependencyInDenormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DependencyInDenormalizer
+{
+    public bool $example;
+    public string $type;
+    public string $format;
+
+    #[VOM\Denormalizer]
+    public function denormalizeData(
+        #[VOM\Argument]
+        string $type,
+        ParameterBagInterface $parameterBag,
+        #[VOM\Argument]
+        ?string $format,
+    ): void {
+        $this->example = $parameterBag->get('example');
+        $this->type = $type;
+        $this->format = $format;
+    }
+}

--- a/tests/Fixtures/DependencyInDenormalizerMissing.php
+++ b/tests/Fixtures/DependencyInDenormalizerMissing.php
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface;
 use Zolex\VOM\Mapping as VOM;
 
 #[VOM\Model]
-class DenormalizerMissingDependency
+class DependencyInDenormalizerMissing
 {
     public string $var;
 

--- a/tests/Fixtures/DependencyInFactory.php
+++ b/tests/Fixtures/DependencyInFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DependencyInFactory
+{
+    public bool $example;
+    public string $type;
+    public string $format;
+
+    #[VOM\Factory]
+    public static function create(
+        #[VOM\Argument]
+        string $type,
+        ParameterBagInterface $parameterBag,
+        #[VOM\Argument]
+        ?string $format,
+    ): self {
+        $obj = new self();
+        $obj->example = $parameterBag->get('example');
+        $obj->type = $type;
+        $obj->format = $format;
+
+        return $obj;
+    }
+}

--- a/tests/Fixtures/DependencyInFactoryMissing.php
+++ b/tests/Fixtures/DependencyInFactoryMissing.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Psr\Log\LoggerInterface;
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DependencyInFactoryMissing
+{
+    public bool $example;
+    public string $type;
+    public string $format;
+
+    #[VOM\Factory]
+    public static function create(
+        #[VOM\Argument]
+        string $type,
+        LoggerInterface $logger,
+        #[VOM\Argument]
+        ?string $format,
+    ): self {
+        return new self();
+    }
+}

--- a/tests/Fixtures/DependencyInNormalizer.php
+++ b/tests/Fixtures/DependencyInNormalizer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DependencyInNormalizer
+{
+    #[VOM\Normalizer]
+    public function normalizeData(
+        ParameterBagInterface $parameterBag,
+    ): array {
+        return [
+            'example' => $parameterBag->get('example'),
+        ];
+    }
+}

--- a/tests/Fixtures/DependencyInNormalizerMissing.php
+++ b/tests/Fixtures/DependencyInNormalizerMissing.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Psr\Log\LoggerInterface;
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class DependencyInNormalizerMissing
+{
+    #[VOM\Normalizer]
+    public function normalizeData(
+        LoggerInterface $logger,
+    ): array {
+        return [];
+    }
+}

--- a/tests/Laravel/Providers/VersatileObjectMapperProviderTest.php
+++ b/tests/Laravel/Providers/VersatileObjectMapperProviderTest.php
@@ -14,15 +14,12 @@ declare(strict_types=1);
 namespace Zolex\VOM\Test\Laravel\Providers;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Zolex\VOM\Laravel\Providers\VersatileObjectMapperProvider;
 use Zolex\VOM\Serializer\VersatileObjectMapper;
 use Zolex\VOM\Test\Laravel\Illuminate\Contracts\Foundation\DummyApplication;
 
 class VersatileObjectMapperProviderTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testSingletonIsRegistered(): void
     {
         $app = new DummyApplication();

--- a/tests/Metadata/ModelMetadataTest.php
+++ b/tests/Metadata/ModelMetadataTest.php
@@ -14,13 +14,16 @@ declare(strict_types=1);
 namespace Zolex\VOM\Test\Metadata;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Zolex\VOM\Mapping\Model;
 use Zolex\VOM\Mapping\Property;
+use Zolex\VOM\Metadata\DependencyInjectionMetadata;
 use Zolex\VOM\Metadata\Exception\RuntimeException;
 use Zolex\VOM\Metadata\Factory\ModelMetadataFactory;
 use Zolex\VOM\Metadata\ModelMetadata;
 use Zolex\VOM\Metadata\PropertyMetadata;
 use Zolex\VOM\PropertyInfo\Extractor\PropertyInfoExtractorFactory;
+use Zolex\VOM\Test\Fixtures\DependencyInConstructor;
 use Zolex\VOM\Test\Fixtures\NestingRoot;
 
 class ModelMetadataTest extends TestCase
@@ -55,5 +58,17 @@ class ModelMetadataTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $metadata->find('levelOne.non.existent', $factory);
+    }
+
+    public function testDeprecatedInjectDenormalizerDependency(): void
+    {
+        $factory = new ModelMetadataFactory(PropertyInfoExtractorFactory::create());
+        $factory->injectDenormalizerDependency(new ParameterBag());
+        $metaData = $factory->getMetadataFor(DependencyInConstructor::class);
+        $args = $metaData->getConstructorArguments();
+        $this->assertArrayHasKey('parameterBag', $args);
+        $this->assertInstanceOf(DependencyInjectionMetadata::class, $args['parameterBag']);
+        $parameterBag = $args['parameterBag']->getValue();
+        $this->assertInstanceOf(ParameterBag::class, $parameterBag);
     }
 }

--- a/tests/Metadata/NormalizerMetadataTest.php
+++ b/tests/Metadata/NormalizerMetadataTest.php
@@ -21,7 +21,7 @@ class NormalizerMetadataTest extends TestCase
 {
     public function testGetMethodAndPropertyName(): void
     {
-        $metadata = new NormalizerMetadata('class', 'getName', 'name', new Normalizer());
+        $metadata = new NormalizerMetadata('class', 'getName', [], new Normalizer(), 'name');
 
         $this->assertEquals('getName', $metadata->getMethod());
         $this->assertEquals('name', $metadata->getPropertyName());
@@ -29,7 +29,7 @@ class NormalizerMetadataTest extends TestCase
 
     public function testGetMethodAndPropertyNameWithNonCompliantName(): void
     {
-        $metadata = new NormalizerMetadata('class', 'somethingElse', 'somethingElse', new Normalizer());
+        $metadata = new NormalizerMetadata('class', 'somethingElse', [], new Normalizer(), 'somethingElse');
 
         $this->assertEquals('somethingElse', $metadata->getMethod());
         $this->assertEquals('somethingElse', $metadata->getPropertyName());

--- a/tests/Serializer/Normalizer/ObjectNormalizerTest.php
+++ b/tests/Serializer/Normalizer/ObjectNormalizerTest.php
@@ -91,7 +91,7 @@ class ObjectNormalizerTest extends TestCase
         $metadataFactory = VersatileObjectMapperFactory::getMetadataFactory();
         $objectNormalizer = VersatileObjectMapperFactory::getObjectNormalizer();
         $metadata = $metadataFactory->getMetadataFor(DateAndTime::class);
-        $metadata->addNormalizer(new NormalizerMetadata('AnotherClass', 'nonExistentDenormalizerMethod', 'virtualName', new Normalizer()));
+        $metadata->addNormalizer(new NormalizerMetadata('AnotherClass', 'nonExistentDenormalizerMethod', [], new Normalizer(), 'virtualName'));
 
         $this->expectException(MappingException::class);
         $this->expectExceptionMessage('Model class "Zolex\VOM\Test\Fixtures\DateAndTime" does not match the expected normalizer class "AnotherClass".');
@@ -104,7 +104,7 @@ class ObjectNormalizerTest extends TestCase
         $metadataFactory = VersatileObjectMapperFactory::getMetadataFactory();
         $objectNormalizer = VersatileObjectMapperFactory::getObjectNormalizer();
         $metadata = $metadataFactory->getMetadataFor(DateAndTime::class);
-        $metadata->addNormalizer(new NormalizerMetadata(DateAndTime::class, 'nonExistentNormalizerMethod', 'virtualName', new Normalizer()));
+        $metadata->addNormalizer(new NormalizerMetadata(DateAndTime::class, 'nonExistentNormalizerMethod', [], new Normalizer(), 'virtualName'));
 
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Bad normalizer method call: Call to undefined method Zolex\VOM\Test\Fixtures\DateAndTime::nonExistentNormalizerMethod()');

--- a/tests/Symfony/Bundle/ZolexVOMBundleTest.php
+++ b/tests/Symfony/Bundle/ZolexVOMBundleTest.php
@@ -49,12 +49,11 @@ class ZolexVOMBundleTest extends KernelTestCase
         }
     }
 
-    public function testParameterBagIsInDenormalizerDependencies(): void
+    public function testMissingConfiguredMethodDependencyThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Denormalizer dependency not found in container: blah');
-        $kernel = self::bootKernel(['environment' => 'dev', 'debug' => false]);
-        $container = $kernel->getContainer();
+        $this->expectExceptionMessage('Method dependency not found in container: blah');
+        self::bootKernel(['environment' => 'dev', 'debug' => false]);
     }
 
     public function testVomIntegratesWithSerializer(): void

--- a/tests/Symfony/Bundle/config/packages/zolex_vom.yaml
+++ b/tests/Symfony/Bundle/config/packages/zolex_vom.yaml
@@ -1,10 +1,11 @@
 zolex_vom:
+  method_dependencies:
+    - '@serializer'
   denormalizer:
     dependencies:
       - '@serializer'
 
 when@dev:
   zolex_vom:
-    denormalizer:
-      dependencies:
-        - '@blah'
+    method_dependencies:
+      - '@blah'

--- a/tools/phpunit/composer.json
+++ b/tools/phpunit/composer.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "phpunit/phpunit": "^10.5",
-        "phpspec/prophecy-phpunit": "^2.1"
+        "phpunit/phpunit": "^10.5"
     }
 }


### PR DESCRIPTION
Replace the old denormalizer-dependencies feature with a backwards compatible method-dependencies feature, that can be used on constructors, factories, normalizers and denormalizers.