### PR TITLE
Relative accessors feature

### DIFF
--- a/src/Mapping/AbstractProperty.php
+++ b/src/Mapping/AbstractProperty.php
@@ -30,6 +30,7 @@ abstract class AbstractProperty
         private bool $serialized = false,
         private ?string $extractor = null,
         private ?string $scenario = ModelMetadata::DEFAULT_SCENARIO,
+        private ?int $relative = null,
     ) {
     }
 
@@ -106,5 +107,10 @@ abstract class AbstractProperty
     public function getScenario(): string
     {
         return $this->scenario;
+    }
+
+    public function getRelative(): ?int
+    {
+        return $this->relative;
     }
 }

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -163,4 +163,9 @@ class PropertyMetadata
     {
         return $this->attribute->getScenario();
     }
+
+    public function getRelative(): ?int
+    {
+        return $this->attribute->getRelative();
+    }
 }

--- a/tests/Fixtures/RelativeNestingLevel0.php
+++ b/tests/Fixtures/RelativeNestingLevel0.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class RelativeNestingLevel0
+{
+    #[VOM\Property]
+    public int $LEVEL_ZERO_VALUE;
+
+    #[VOM\Property]
+    public RelativeNestingLevel1 $LEVEL_ONE;
+}

--- a/tests/Fixtures/RelativeNestingLevel1.php
+++ b/tests/Fixtures/RelativeNestingLevel1.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class RelativeNestingLevel1
+{
+    #[VOM\Property(accessor: '[LEVEL_ZERO_VALUE]', relative: 1)]
+    public int $LEVEL_ONE_VALUE;
+
+    #[VOM\Property]
+    public RelativeNestingLevel2 $LEVEL_TWO;
+}

--- a/tests/Fixtures/RelativeNestingLevel2.php
+++ b/tests/Fixtures/RelativeNestingLevel2.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class RelativeNestingLevel2
+{
+    #[VOM\Property]
+    public int $LEVEL_TWO_VALUE;
+
+    #[VOM\Property(accessor: '[LEVEL_TWO]', relative: 1)]
+    public RelativeNestingLevel3 $LEVEL_THREE;
+}

--- a/tests/Fixtures/RelativeNestingLevel3.php
+++ b/tests/Fixtures/RelativeNestingLevel3.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class RelativeNestingLevel3
+{
+    #[VOM\Property(accessor: '[LEVEL_TWO_VALUE]')]
+    public int $LEVEL_THREE_VALUE;
+
+    #[VOM\Property(accessor: '[LEVEL_THREE]')]
+    public RelativeNestingLevel4 $LEVEL_FOUR;
+}

--- a/tests/Fixtures/RelativeNestingLevel4.php
+++ b/tests/Fixtures/RelativeNestingLevel4.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the VOM package.
+ *
+ * (c) Andreas Linden <zlx@gmx.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zolex\VOM\Test\Fixtures;
+
+use Zolex\VOM\Mapping as VOM;
+
+#[VOM\Model]
+class RelativeNestingLevel4
+{
+    #[VOM\Property(accessor: '[LEVEL_ONE_VALUE]', relative: 2)]
+    public int $LEVEL_FOUR_VALUE;
+}

--- a/tests/Serializer/VersatileObjectMapperTest.php
+++ b/tests/Serializer/VersatileObjectMapperTest.php
@@ -77,6 +77,11 @@ use Zolex\VOM\Test\Fixtures\PrivateNormalizer;
 use Zolex\VOM\Test\Fixtures\PropertyPromotion;
 use Zolex\VOM\Test\Fixtures\RegexpExtractorModel;
 use Zolex\VOM\Test\Fixtures\RegexpExtractorProperty;
+use Zolex\VOM\Test\Fixtures\RelativeNestingLevel0;
+use Zolex\VOM\Test\Fixtures\RelativeNestingLevel1;
+use Zolex\VOM\Test\Fixtures\RelativeNestingLevel2;
+use Zolex\VOM\Test\Fixtures\RelativeNestingLevel3;
+use Zolex\VOM\Test\Fixtures\RelativeNestingLevel4;
 use Zolex\VOM\Test\Fixtures\ScenarioConstructorArguments;
 use Zolex\VOM\Test\Fixtures\ScenarioConstructorPropertyPromotion;
 use Zolex\VOM\Test\Fixtures\ScenarioDenormalizer;
@@ -1303,6 +1308,42 @@ class VersatileObjectMapperTest extends TestCase
         $normalized = self::$serializer->normalize($nestingRoot);
 
         $this->assertEquals($data, $normalized);
+    }
+
+    public function testRelativeNesting(): void
+    {
+        $data = [
+            'LEVEL_ZERO_VALUE' => 0,
+            'LEVEL_ONE' => [
+                'LEVEL_ONE_VALUE' => 1,
+                'LEVEL_TWO' => [
+                    'LEVEL_TWO_VALUE' => 2,
+                    'LEVEL_THREE' => [
+                        'LEVEL_THREE_VALUE' => 3,
+                        'LEVEL_FOUR' => [
+                            'LEVEL_FOUR_VALUE' => 4,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $relativeBrainfuck = self::$serializer->denormalize($data, RelativeNestingLevel0::class);
+
+        $this->assertInstanceOf(RelativeNestingLevel0::class, $relativeBrainfuck);
+        $this->assertEquals(0, $relativeBrainfuck->LEVEL_ZERO_VALUE);
+
+        $this->assertInstanceOf(RelativeNestingLevel1::class, $relativeBrainfuck->LEVEL_ONE);
+        $this->assertEquals(0, $relativeBrainfuck->LEVEL_ONE->LEVEL_ONE_VALUE);
+
+        $this->assertInstanceOf(RelativeNestingLevel2::class, $relativeBrainfuck->LEVEL_ONE->LEVEL_TWO);
+        $this->assertEquals(2, $relativeBrainfuck->LEVEL_ONE->LEVEL_TWO->LEVEL_TWO_VALUE);
+
+        $this->assertInstanceOf(RelativeNestingLevel3::class, $relativeBrainfuck->LEVEL_ONE->LEVEL_TWO->LEVEL_THREE);
+        $this->assertEquals(2, $relativeBrainfuck->LEVEL_ONE->LEVEL_TWO->LEVEL_THREE->LEVEL_THREE_VALUE);
+
+        $this->assertInstanceOf(RelativeNestingLevel4::class, $relativeBrainfuck->LEVEL_ONE->LEVEL_TWO->LEVEL_THREE->LEVEL_FOUR);
+        $this->assertEquals(1, $relativeBrainfuck->LEVEL_ONE->LEVEL_TWO->LEVEL_THREE->LEVEL_FOUR->LEVEL_FOUR_VALUE);
     }
 
     public function testObjectToPopulate(): void


### PR DESCRIPTION
Relative accessors make it possible to apply an accessor from a certain number of levels upwards in the data structure.